### PR TITLE
make clock argument of InMemoryCache constructor explicitly nullable

### DIFF
--- a/src/InMemoryCache.php
+++ b/src/InMemoryCache.php
@@ -17,7 +17,7 @@ final class InMemoryCache implements CacheItemPoolInterface
     private array $deferredItems;
 
     public function __construct(
-        ClockInterface $clock = null,
+        ?ClockInterface $clock = null,
     ) {
         $this->clock = $clock ?? new class implements ClockInterface {
             public function now(): DateTimeImmutable


### PR DESCRIPTION
On php8.4 there is a new deprecation, when providing a null default value to a method argument without making that argument nullable, this tiny pr fixes that and removes the depcrecation warning.